### PR TITLE
Entry points proposal spec and implementation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,6 +38,7 @@ module.exports = {
     {
       files: [
         'doc/api/esm.md',
+        'test/es-module/test-esm-type-flag.js',
         '*.mjs',
       ],
       parserOptions: { sourceType: 'module' },

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -485,6 +485,18 @@ added: v2.4.0
 
 Track heap object allocations for heap snapshots.
 
+### `-m`, `--type=type`
+
+When using `--experimental-modules`, this informs the module resolution type
+to interpret the top-level entry into Node.js.
+
+Works with stdin, `--eval`, `--print` as well as standard execution.
+
+Valid values are `"commonjs"` and `"module"`, where the default is to infer
+from the file extension and package type boundary.
+
+`-m` is an alias for `--type=module`.
+
 ### `--use-bundled-ca`, `--use-openssl-ca`
 <!-- YAML
 added: v6.11.0

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -2196,6 +2196,27 @@ A non-specific HTTP/2 error has occurred.
 Used in the `repl` in case the old history file is used and an error occurred
 while trying to read and parse it.
 
+<a id="ERR_INVALID_REPL_TYPE"></a>
+### ERR_INVALID_REPL_TYPE
+
+> Stability: 1 - Experimental
+
+The `--type=...` flag is not compatible with the Node.js REPL.
+
+<a id="ERR_INVALID_TYPE_EXTENSION"></a>
+### ERR_INVALID_TYPE_EXTENSION
+
+> Stability: 1 - Experimental
+
+Attempted to execute a `.cjs` module with the `--type=module` flag.
+
+<a id="ERR_INVALID_TYPE_FLAG"></a>
+### ERR_INVALID_TYPE_FLAG
+
+> Stability: 1 - Experimental
+
+An invalid `--type=...` flag value was provided.
+
 <a id="ERR_MISSING_DYNAMIC_INSTANTIATE_HOOK"></a>
 #### ERR_MISSING_DYNAMIC_INSTANTIATE_HOOK
 
@@ -2225,7 +2246,6 @@ size.
 
 This `Error` is thrown when a read is attempted on a TTY `WriteStream`,
 such as `process.stdout.on('data')`.
-
 
 [`'uncaughtException'`]: process.html#process_event_uncaughtexception
 [`--force-fips`]: cli.html#cli_force_fips

--- a/doc/node.1
+++ b/doc/node.1
@@ -272,6 +272,9 @@ Print stack traces for process warnings (including deprecations).
 .It Fl -track-heap-objects
 Track heap object allocations for heap snapshots.
 .
+.It Fl -type Ns = Ns Ar type
+Set the top-level module resolution type.
+.
 .It Fl -use-bundled-ca , Fl -use-openssl-ca
 Use bundled Mozilla CA store as supplied by current Node.js version or use OpenSSL's default CA store.
 The default store is selectable at build-time.

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -780,6 +780,8 @@ E('ERR_INVALID_PROTOCOL',
   TypeError);
 E('ERR_INVALID_REPL_EVAL_CONFIG',
   'Cannot specify both "breakEvalOnSigint" and "eval" for REPL', TypeError);
+E('ERR_INVALID_REPL_TYPE',
+  'Cannot specify --type for REPL', TypeError);
 E('ERR_INVALID_RETURN_PROPERTY', (input, name, prop, value) => {
   return `Expected a valid ${input} to be returned for the "${prop}" from the` +
          ` "${name}" function but got ${value}.`;
@@ -810,6 +812,11 @@ E('ERR_INVALID_SYNC_FORK_INPUT',
   TypeError);
 E('ERR_INVALID_THIS', 'Value of "this" must be of type %s', TypeError);
 E('ERR_INVALID_TUPLE', '%s must be an iterable %s tuple', TypeError);
+E('ERR_INVALID_TYPE_EXTENSION', '%s extension is not supported for --type=%s',
+  TypeError);
+E('ERR_INVALID_TYPE_FLAG',
+  'Type flag must be one of "esm", "commonjs". Received --type=%s',
+  TypeError);
 E('ERR_INVALID_URI', 'URI malformed', URIError);
 E('ERR_INVALID_URL', 'Invalid URL: %s', TypeError);
 E('ERR_INVALID_URL_SCHEME',
@@ -964,12 +971,10 @@ E('ERR_UNHANDLED_ERROR',
 // This should probably be a `TypeError`.
 E('ERR_UNKNOWN_CREDENTIAL', '%s identifier does not exist: %s', Error);
 E('ERR_UNKNOWN_ENCODING', 'Unknown encoding: %s', TypeError);
-
+E('ERR_UNKNOWN_FILE_EXTENSION', 'Unknown file extension: %s', TypeError);
 // This should probably be a `TypeError`.
 E('ERR_UNKNOWN_MODULE_FORMAT', 'Unknown module format: %s', RangeError);
 E('ERR_UNKNOWN_SIGNAL', 'Unknown signal: %s', TypeError);
-E('ERR_UNSUPPORTED_FILE_EXTENSION', 'Unsupported file extension: \'%s\' ' +
-  'imported from %s', Error);
 
 E('ERR_V8BREAKITERATOR',
   'Full ICU data not installed. See https://github.com/nodejs/node/wiki/Intl',

--- a/lib/internal/main/check_syntax.js
+++ b/lib/internal/main/check_syntax.js
@@ -11,6 +11,8 @@ const {
   readStdin
 } = require('internal/process/execution');
 
+const { pathToFileURL } = require('url');
+
 const CJSModule = require('internal/modules/cjs/loader');
 const vm = require('vm');
 const {
@@ -32,20 +34,39 @@ if (process.argv[1] && process.argv[1] !== '-') {
   prepareMainThreadExecution();
   markBootstrapComplete();
 
-  checkScriptSyntax(source, filename);
+  checkSyntax(source, filename);
 } else {
   // TODO(joyeecheung): not every one of these are necessary
   prepareMainThreadExecution();
   markBootstrapComplete();
 
   readStdin((code) => {
-    checkScriptSyntax(code, '[stdin]');
+    checkSyntax(code, '[stdin]');
   });
 }
 
-function checkScriptSyntax(source, filename) {
+function checkSyntax(source, filename) {
   // Remove Shebang.
   source = stripShebang(source);
+
+  const experimentalModules =
+      require('internal/options').getOptionValue('--experimental-modules');
+  if (experimentalModules) {
+    let isModule = false;
+    if (filename === '[stdin]' || filename === '[eval]') {
+      isModule = require('internal/process/esm_loader').typeFlag === 'module';
+    } else {
+      const resolve = require('internal/modules/esm/default_resolve');
+      const { format } = resolve(pathToFileURL(filename).toString());
+      isModule = format === 'esm';
+    }
+    if (isModule) {
+      const { ModuleWrap } = internalBinding('module_wrap');
+      new ModuleWrap(source, filename);
+      return;
+    }
+  }
+
   // Remove BOM.
   source = stripBOM(source);
   // Wrap it.

--- a/lib/internal/main/eval_stdin.js
+++ b/lib/internal/main/eval_stdin.js
@@ -7,6 +7,7 @@ const {
 } = require('internal/bootstrap/pre_execution');
 
 const {
+  evalModule,
   evalScript,
   readStdin
 } = require('internal/process/execution');
@@ -16,5 +17,8 @@ markBootstrapComplete();
 
 readStdin((code) => {
   process._eval = code;
-  evalScript('[stdin]', process._eval, process._breakFirstLine);
+  if (require('internal/process/esm_loader').typeFlag === 'module')
+    evalModule(process._eval);
+  else
+    evalScript('[stdin]', process._eval, process._breakFirstLine);
 });

--- a/lib/internal/main/eval_string.js
+++ b/lib/internal/main/eval_string.js
@@ -6,11 +6,14 @@
 const {
   prepareMainThreadExecution
 } = require('internal/bootstrap/pre_execution');
-const { evalScript } = require('internal/process/execution');
+const { evalModule, evalScript } = require('internal/process/execution');
 const { addBuiltinLibsToObject } = require('internal/modules/cjs/helpers');
 
 const source = require('internal/options').getOptionValue('--eval');
 prepareMainThreadExecution();
 addBuiltinLibsToObject(global);
 markBootstrapComplete();
-evalScript('[eval]', source, process._breakFirstLine);
+if (require('internal/process/esm_loader').typeFlag === 'module')
+  evalModule(source);
+else
+  evalScript('[eval]', source, process._breakFirstLine);

--- a/lib/internal/main/repl.js
+++ b/lib/internal/main/repl.js
@@ -11,7 +11,14 @@ const {
   evalScript
 } = require('internal/process/execution');
 
+const { ERR_INVALID_REPL_TYPE } = require('internal/errors').codes;
+
 prepareMainThreadExecution();
+
+// --type flag not supported in REPL
+if (require('internal/process/esm_loader').typeFlag) {
+  throw ERR_INVALID_REPL_TYPE();
+}
 
 const cliRepl = require('internal/repl');
 cliRepl.createInternalRepl(process.env, (err, repl) => {

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -786,21 +786,21 @@ if (experimentalModules) {
 // bootstrap main module.
 Module.runMain = function() {
   // Load the main module--the command line argument.
-  const base = path.basename(process.argv[1]);
-  const ext = path.extname(base);
-  const isESM = ext === '.mjs';
-
-  if (experimentalModules && isESM) {
+  if (experimentalModules) {
     if (asyncESM === undefined) lazyLoadESM();
-    asyncESM.loaderPromise.then((loader) => {
-      return loader.import(pathToFileURL(process.argv[1]).pathname);
-    })
-    .catch((e) => {
-      internalBinding('util').triggerFatalException(e);
-    });
-  } else {
-    Module._load(process.argv[1], null, true);
+    if (asyncESM.typeFlag !== 'commonjs') {
+      asyncESM.loaderPromise.then((loader) => {
+        return loader.import(pathToFileURL(process.argv[1]).pathname);
+      })
+      .catch((e) => {
+        internalBinding('util').triggerFatalException(e);
+      });
+      // Handle any nextTicks added in the first tick of the program
+      process._tickCallback();
+      return;
+    }
   }
+  Module._load(process.argv[1], null, true);
   // Handle any nextTicks added in the first tick of the program
   process._tickCallback();
 };

--- a/lib/internal/modules/esm/default_resolve.js
+++ b/lib/internal/modules/esm/default_resolve.js
@@ -7,20 +7,23 @@ const { realpathSync } = require('fs');
 const { getOptionValue } = require('internal/options');
 const preserveSymlinks = getOptionValue('--preserve-symlinks');
 const preserveSymlinksMain = getOptionValue('--preserve-symlinks-main');
-const { ERR_UNSUPPORTED_FILE_EXTENSION } = require('internal/errors').codes;
+const { ERR_UNKNOWN_FILE_EXTENSION } = require('internal/errors').codes;
 const { resolve: moduleWrapResolve } = internalBinding('module_wrap');
 const { pathToFileURL, fileURLToPath } = require('internal/url');
+const { typeFlag } = require('internal/process/esm_loader');
 
 const realpathCache = new Map();
 
 const extensionFormatMap = {
   '__proto__': null,
-  '.mjs': 'esm',
-  '.js': 'esm'
+  '.cjs': 'cjs',
+  '.js': 'esm',
+  '.mjs': 'esm'
 };
 
 const legacyExtensionFormatMap = {
   '__proto__': null,
+  '.cjs': 'cjs',
   '.js': 'cjs',
   '.json': 'cjs',
   '.mjs': 'esm',
@@ -39,7 +42,10 @@ function resolve(specifier, parentURL) {
   if (isMain)
     parentURL = pathToFileURL(`${process.cwd()}/`).href;
 
-  const resolved = moduleWrapResolve(specifier, parentURL, isMain);
+  const resolved = moduleWrapResolve(specifier,
+                                     parentURL,
+                                     isMain,
+                                     typeFlag === 'module');
 
   let url = resolved.url;
   const legacy = resolved.legacy;
@@ -61,8 +67,8 @@ function resolve(specifier, parentURL) {
     if (isMain)
       format = legacy ? 'cjs' : 'esm';
     else
-      throw new ERR_UNSUPPORTED_FILE_EXTENSION(fileURLToPath(url),
-                                               fileURLToPath(parentURL));
+      throw new ERR_UNKNOWN_FILE_EXTENSION(fileURLToPath(url),
+                                           fileURLToPath(parentURL));
   }
 
   return { url: `${url}`, format };

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -11,10 +11,12 @@ const { URL } = require('url');
 const { validateString } = require('internal/validators');
 const ModuleMap = require('internal/modules/esm/module_map');
 const ModuleJob = require('internal/modules/esm/module_job');
+
 const defaultResolve = require('internal/modules/esm/default_resolve');
 const createDynamicModule = require(
   'internal/modules/esm/create_dynamic_module');
 const { translators } = require('internal/modules/esm/translators');
+const { ModuleWrap } = internalBinding('module_wrap');
 
 const FunctionBind = Function.call.bind(Function.prototype.bind);
 
@@ -51,6 +53,8 @@ class Loader {
     // an object with the same keys as `exports`, whose values are get/set
     // functions for the actual exported values.
     this._dynamicInstantiate = undefined;
+    // The index for assigning unique URLs to anonymous module evaluation
+    this.evalIndex = 0;
   }
 
   async resolve(specifier, parentURL) {
@@ -98,9 +102,25 @@ class Loader {
     return { url, format };
   }
 
+  async eval(source, url = `eval:${++this.evalIndex}`) {
+    const evalInstance = async (url) => {
+      return {
+        module: new ModuleWrap(source, url),
+        reflect: undefined
+      };
+    };
+    const job = new ModuleJob(this, url, evalInstance, false);
+    this.moduleMap.set(url, job);
+    const { module, result } = await job.run();
+    return {
+      namespace: module.namespace(),
+      result
+    };
+  }
+
   async import(specifier, parent) {
     const job = await this.getModuleJob(specifier, parent);
-    const module = await job.run();
+    const { module } = await job.run();
     return module.namespace();
   }
 
@@ -146,4 +166,4 @@ class Loader {
 
 Object.setPrototypeOf(Loader.prototype, null);
 
-module.exports = Loader;
+exports.Loader = Loader;

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -101,8 +101,7 @@ class ModuleJob {
 
   async run() {
     const module = await this.instantiate();
-    module.evaluate(-1, false);
-    return module;
+    return { module, result: module.evaluate(-1, false) };
   }
 }
 Object.setPrototypeOf(ModuleJob.prototype, null);

--- a/lib/internal/process/esm_loader.js
+++ b/lib/internal/process/esm_loader.js
@@ -3,14 +3,20 @@
 const {
   callbackMap,
 } = internalBinding('module_wrap');
+const {
+  ERR_INVALID_TYPE_FLAG,
+  ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING,
+} = require('internal/errors').codes;
 
-const Loader = require('internal/modules/esm/loader');
+const type = require('internal/options').getOptionValue('--type');
+if (type && type !== 'commonjs' && type !== 'module')
+  throw new ERR_INVALID_TYPE_FLAG(type);
+exports.typeFlag = type;
+
+const { Loader } = require('internal/modules/esm/loader');
 const {
   wrapToModuleMap,
 } = require('internal/vm/source_text_module');
-const {
-  ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING,
-} = require('internal/errors').codes;
 
 exports.initializeImportMetaObject = function(wrap, meta) {
   if (callbackMap.has(wrap)) {

--- a/lib/internal/process/execution.js
+++ b/lib/internal/process/execution.js
@@ -33,6 +33,24 @@ function tryGetCwd() {
   }
 }
 
+function evalModule(source) {
+  const { decorateErrorStack } = require('internal/util');
+  const asyncESM = require('internal/process/esm_loader');
+  asyncESM.loaderPromise.then(async (loader) => {
+    const { result } = await loader.eval(source);
+    if (require('internal/options').getOptionValue('--print')) {
+      console.log(result);
+    }
+  })
+  .catch((e) => {
+    decorateErrorStack(e);
+    console.error(e);
+    process.exit(1);
+  });
+  // Handle any nextTicks added in the first tick of the program.
+  process._tickCallback();
+}
+
 function evalScript(name, body, breakFirstLine) {
   const CJSModule = require('internal/modules/cjs/loader');
   const { kVmBreakFirstLineSymbol } = require('internal/util');
@@ -180,6 +198,7 @@ function readStdin(callback) {
 module.exports = {
   readStdin,
   tryGetCwd,
+  evalModule,
   evalScript,
   fatalException: createFatalException(),
   setUncaughtExceptionCaptureCallback,

--- a/src/env.h
+++ b/src/env.h
@@ -177,7 +177,6 @@ constexpr size_t kFsStatsBufferLength = kFsStatsFieldsNumber * 2;
   V(env_var_settings_string, "envVarSettings")                                 \
   V(errno_string, "errno")                                                     \
   V(error_string, "error")                                                     \
-  V(esm_string, "esm")                                                         \
   V(exchange_string, "exchange")                                               \
   V(exit_code_string, "exitCode")                                              \
   V(expire_string, "expire")                                                   \

--- a/src/module_wrap.h
+++ b/src/module_wrap.h
@@ -28,10 +28,6 @@ struct ModuleResolution {
   bool legacy;
 };
 
-v8::Maybe<ModuleResolution> Resolve(Environment* env,
-                                    const std::string& specifier,
-                                    const url::URL& base);
-
 class ModuleWrap : public BaseObject {
  public:
   static const std::string EXTENSIONS[];

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -209,10 +209,12 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             kAllowedInEnvironment);
   AddOption("--preserve-symlinks",
             "preserve symbolic links when resolving",
-            &EnvironmentOptions::preserve_symlinks);
+            &EnvironmentOptions::preserve_symlinks,
+            kAllowedInEnvironment);
   AddOption("--preserve-symlinks-main",
             "preserve symbolic links when resolving the main module",
-            &EnvironmentOptions::preserve_symlinks_main);
+            &EnvironmentOptions::preserve_symlinks_main,
+            kAllowedInEnvironment);
   AddOption("--prof-process",
             "process V8 profiler output generated using --prof",
             &EnvironmentOptions::prof_process);
@@ -238,6 +240,10 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
   AddOption("--trace-warnings",
             "show stack traces on process warnings",
             &EnvironmentOptions::trace_warnings,
+            kAllowedInEnvironment);
+  AddOption("--type",
+            "top-level module type name",
+            &EnvironmentOptions::module_type,
             kAllowedInEnvironment);
 
   AddOption("--check",

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -86,6 +86,7 @@ class EnvironmentOptions : public Options {
  public:
   bool abort_on_uncaught_exception = false;
   bool experimental_modules = false;
+  std::string module_type;
   std::string experimental_policy;
   bool experimental_repl_await = false;
   bool experimental_vm_modules = false;

--- a/test/es-module/test-esm-loader-modulemap.js
+++ b/test/es-module/test-esm-loader-modulemap.js
@@ -7,7 +7,7 @@
 const common = require('../common');
 
 const { URL } = require('url');
-const Loader = require('internal/modules/esm/loader');
+const { Loader } = require('internal/modules/esm/loader');
 const ModuleMap = require('internal/modules/esm/module_map');
 const ModuleJob = require('internal/modules/esm/module_job');
 const createDynamicModule = require(

--- a/test/es-module/test-esm-type-flag.js
+++ b/test/es-module/test-esm-type-flag.js
@@ -1,0 +1,11 @@
+// Flags: --experimental-modules --type=module
+/* eslint-disable node-core/required-modules */
+import cjs from '../fixtures/baz.js';
+import '../common/index.mjs';
+import { message } from '../fixtures/es-modules/message.mjs';
+import assert from 'assert';
+
+// Assert we loaded esm dependency as ".js" in this mode
+assert.strictEqual(message, 'A message');
+// Assert we loaded CommonJS dependency
+assert.strictEqual(cjs, 'perhaps I work');

--- a/test/parallel/test-cli-syntax-piped-bad.js
+++ b/test/parallel/test-cli-syntax-piped-bad.js
@@ -8,24 +8,45 @@ const node = process.execPath;
 
 // test both sets of arguments that check syntax
 const syntaxArgs = [
-  ['-c'],
-  ['--check']
+  '-c',
+  '--check'
 ];
 
 // Match on the name of the `Error` but not the message as it is different
 // depending on the JavaScript engine.
-const syntaxErrorRE = /^SyntaxError: \b/m;
+const syntaxErrorRE = /^SyntaxError: Unexpected identifier\b/m;
 
 // Should throw if code piped from stdin with --check has bad syntax
 // loop each possible option, `-c` or `--check`
-syntaxArgs.forEach(function(args) {
+syntaxArgs.forEach(function(arg) {
   const stdin = 'var foo bar;';
-  const c = spawnSync(node, args, { encoding: 'utf8', input: stdin });
+  const c = spawnSync(node, [arg], { encoding: 'utf8', input: stdin });
 
   // stderr should include '[stdin]' as the filename
   assert(c.stderr.startsWith('[stdin]'), `${c.stderr} starts with ${stdin}`);
 
-  // no stdout or stderr should be produced
+  // no stdout should be produced
+  assert.strictEqual(c.stdout, '');
+
+  // stderr should have a syntax error message
+  assert(syntaxErrorRE.test(c.stderr), `${syntaxErrorRE} === ${c.stderr}`);
+
+  assert.strictEqual(c.status, 1);
+});
+
+// Check --type=module
+syntaxArgs.forEach(function(arg) {
+  const stdin = 'export var p = 5; var foo bar;';
+  const c = spawnSync(
+    node,
+    ['--experimental-modules', '--type=module', '--no-warnings', arg],
+    { encoding: 'utf8', input: stdin }
+  );
+
+  // stderr should include '[stdin]' as the filename
+  assert(c.stderr.startsWith('[stdin]'), `${c.stderr} starts with ${stdin}`);
+
+  // no stdout should be produced
   assert.strictEqual(c.stdout, '');
 
   // stderr should have a syntax error message

--- a/test/parallel/test-cli-syntax-piped-good.js
+++ b/test/parallel/test-cli-syntax-piped-good.js
@@ -8,15 +8,31 @@ const node = process.execPath;
 
 // test both sets of arguments that check syntax
 const syntaxArgs = [
-  ['-c'],
-  ['--check']
+  '-c',
+  '--check'
 ];
 
 // Should not execute code piped from stdin with --check.
 // Loop each possible option, `-c` or `--check`.
-syntaxArgs.forEach(function(args) {
+syntaxArgs.forEach(function(arg) {
   const stdin = 'throw new Error("should not get run");';
-  const c = spawnSync(node, args, { encoding: 'utf8', input: stdin });
+  const c = spawnSync(node, [arg], { encoding: 'utf8', input: stdin });
+
+  // no stdout or stderr should be produced
+  assert.strictEqual(c.stdout, '');
+  assert.strictEqual(c.stderr, '');
+
+  assert.strictEqual(c.status, 0);
+});
+
+// Check --type=module
+syntaxArgs.forEach(function(arg) {
+  const stdin = 'export var p = 5; throw new Error("should not get run");';
+  const c = spawnSync(
+    node,
+    ['--experimental-modules', '--no-warnings', '--type=module', arg],
+    { encoding: 'utf8', input: stdin }
+  );
 
   // no stdout or stderr should be produced
   assert.strictEqual(c.stdout, '');


### PR DESCRIPTION
This implements a top-level `--type` flag for `--experimental-modules` with the following behaviours.

In addition `"type": "esm"` in the package.json is renamed to `"type": "module"`, and a new extension `.cjs` is supported.

These behaviours are as defined in https://github.com/GeoffreyBooth/node-esm-entry-points-proposal.

* `node --experimental-modules ./x.unknown --type=module` will always execute the top-level file as an ES module, unless it ends in `.cjs`, in which case an error is thrown.
* `node --experimental-modules ./x.unknown --type=commonjs` will always execute the top-level file as a CommonJS module.
* Support `node --experimental-modules` flags `--check`, `--print`, `-e` and stdin, including compatibility with `--type`
* New error types are defined to handle the failure cases on these new flags.

With this PR, we get both the package.json boundary as the module format hint, as well as an ability to now override the format to a known format.

As with all previous PRs there are two commits - one with just the spec/doc changes, and another with the implementation.

The following features in the entry points proposal are not yet implemented in this PR and should be implemented as follow-up work:
* `--type=auto` for syntax detection
* symlink handling at the top-level boundary
* `-m` alias for `--type=module`