### PR TITLE
Docs, of the implementation as it is right this moment

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -513,13 +513,13 @@ Track heap object allocations for heap snapshots.
 
 ### `-m`, `--type=type`
 
-With `--experimental-modules`, this tells Node.js whether to interpret the
+Used with `--experimental-modules`, this configures Node.js to interpret the
 initial entry point as CommonJS or as an ES module.
 
-Valid values are `"commonjs"` and `"module"`, where the default is to infer from
+Valid values are `"commonjs"` and `"module"`. The default is to infer from
 the file extension and the `"type"` field in the nearest parent `package.json`.
 
-Works with standard file input as well as `--eval`, `--print`, `STDIN`.
+Works for executing a file as well as `--eval`, `--print`, `STDIN`.
 
 `-m` is an alias for `--type=module`.
 

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -513,13 +513,13 @@ Track heap object allocations for heap snapshots.
 
 ### `-m`, `--type=type`
 
-When using `--experimental-modules`, this informs the module resolution type
-to interpret the top-level entry into Node.js.
+With `--experimental-modules`, this tells Node.js whether to interpret the
+initial entry point as CommonJS or as an ES module.
 
-Works with stdin, `--eval`, `--print` as well as standard execution.
+Valid values are `"commonjs"` and `"module"`, where the default is to infer from
+the file extension and the `"type"` field in the nearest parent `package.json`.
 
-Valid values are `"commonjs"` and `"module"`, where the default is to infer
-from the file extension and package type boundary.
+Works with standard file input as well as `--eval`, `--print`, `STDIN`.
 
 `-m` is an alias for `--type=module`.
 

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -49,7 +49,7 @@ For completeness there is also `--type=commonjs`, for explicitly running a `.js`
 file as CommonJS. This is the default behavior if `--type` or `-m` is
 unspecified.
 
-The `--type=module` or `-m` flags can also be used to tell Node.js to treat as
+The `--type=module` or `-m` flags can also be used to configure Node.js to treat as
 an ES module input sent in via `--eval` or `--print` (or `-e` or `-p`) or piped
 to Node.js via `STDIN`.
 
@@ -87,7 +87,7 @@ node --experimental-modules my-app.js # Runs as ES module
 If the nearest parent `package.json` lacks a `"type"` field, or contains
 `"type": "commonjs"`, extensionless and `.js` files are treated as CommonJS.
 If the volume root is reached and no `package.json` is found,
-Node.js behaves the same as if it had found a `package.json` with no `"type"`
+Node.js defers to the deafult, a `package.json` with no `"type"`
 field.
 
 ## Package Scope and File Extensions

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -341,9 +341,9 @@ module.exports = 'cjs';
 
 // esm.mjs
 import { createRequireFromPath as createRequire } from 'module';
-import { fileURLToPath as fromPath } from 'url';
+import { fileURLToPath as fromURL } from 'url';
 
-const require = createRequire(fromPath(import.meta.url));
+const require = createRequire(fromURL(import.meta.url));
 
 const cjs = require('./cjs');
 cjs === 'cjs'; // true

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -147,6 +147,48 @@ package scope:
   extension (since both `.js` and `.cjs` files are treated as CommonJS within a
   `"commonjs"` package scope).
 
+## Package Entry Points
+
+When a `package.json` contains `"type": "module"`, its `"main"` field defines
+the ES module entry point for the package.
+
+<!-- eslint-skip -->
+```js
+// ./node_modules/es-module-package/package.json
+{
+  "type": "module",
+  "main": "./src/index.js"
+}
+```
+```js
+// ./my-app.mjs
+
+import { something } from 'es-module-package';
+// Loads from ./node_modules/es-module-package/src/index.js
+```
+
+An attempt to `require` the above `es-module-package` would attempt to load
+`./node_modules/es-module-package/src/index.js` as CommonJS, which would throw
+an error as Node.js would not be able to parse the `export` statement in
+CommonJS.
+
+Even if the `package.json` `"main"` points to a file ending in `.mjs`, the
+`"type": "module"` is required.
+
+As with `import` statements, for ES module usage the value of `"main"` must be
+a full path including extension: `"./index.mjs"`, not `"./index"`.
+
+> Currently a package can define _either_ a CommonJS entry point or an ES module
+> entry point; there is no way to specify separate entry points for CommonJS and
+> ES module usage. This means that a package entry point can be included via
+> `require` or via `import` but not both.
+>
+> Such a limitation makes it difficult for packages to support both new versions
+> of Node.js that understand ES modules and older versions of Node.js that
+> understand only CommonJS. There is work ongoing to remove this limitation, and
+> it will very likely entail changes to the behavior of `"main"` as defined
+> here.
+
 ## import.meta
 
 * {Object}

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -151,8 +151,9 @@ package scope:
 
 ## Package Entry Points
 
-When a `package.json` contains `"type": "module"`, its `"main"` field defines
-the ES module entry point for the package.
+The `package.json` `"main"` field defines the entry point for a package,
+whether the package is included into CommonJS via `require` or into an ES
+module via `import`.
 
 <!-- eslint-skip -->
 ```js
@@ -176,6 +177,9 @@ CommonJS.
 
 As with `import` statements, for ES module usage the value of `"main"` must be
 a full path including extension: `"./index.mjs"`, not `"./index"`.
+
+If the `package.json` `"type"` field is omitted, a `.js` file in `"main"` will
+be interpreted as CommonJS.
 
 > Currently a package can define _either_ a CommonJS entry point **or** an ES
 > module entry point; there is no way to specify separate entry points for


### PR DESCRIPTION
This PR updates the docs for where the implementation is currently. The idea is to reflect it as it is, not as it’s eventually going to be; when the expected future changes land, the docs should be updated accordingly. The old `--experimental-modules` docs are [here](https://nodejs.org/api/esm.html).

Readable versions:
- https://github.com/nodejs/ecmascript-modules/blob/docs/doc/api/esm.md
- https://github.com/nodejs/ecmascript-modules/blob/docs/doc/api/cli.md
