### PR TITLE
doc: improve createRequire example

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -341,9 +341,9 @@ module.exports = 'cjs';
 
 // esm.mjs
 import { createRequireFromPath as createRequire } from 'module';
-import { fileURLToPath as fromPath } from 'url';
+import { fileURLToPath as fromURL } from 'url';
 
-const require = createRequire(fromPath(import.meta.url));
+const require = createRequire(fromURL(import.meta.url));
 
 const cjs = require('./cjs');
 cjs === 'cjs'; // true


### PR DESCRIPTION
Original doesn't really make sense in retrospect

updates example to

```mjs
// cjs.js
module.exports = 'cjs';

// esm.mjs
import { createRequireFromPath as createRequire } from 'module';
import { fileURLToPath as fromURL } from 'url';

const require = createRequire(fromURL(import.meta.url));

const cjs = require('./cjs');
cjs === 'cjs'; // true
```