### PR TITLE
src: do not allow ESM flags without --experimental-modules

### DIFF
--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -107,6 +107,26 @@ void EnvironmentOptions::CheckOptions(std::vector<std::string>* errors) {
     errors->push_back("--loader requires --experimental-modules be enabled");
   }
 
+  if (!module_type.empty() && !experimental_modules) {
+    errors->push_back("--type requires --experimental-modules be enabled");
+  }
+
+  if (experimental_json_modules && !experimental_modules) {
+    errors->push_back("--experimental-json-modules requires "
+                      "--experimental-modules be enabled");
+  }
+
+  if (!es_module_specifier_resolution.empty()) {
+    if (!experimental_modules) {
+      errors->push_back("--es-module-specifier-resolution requires "
+                        "--experimental-modules be enabled");
+    }
+    if (es_module_specifier_resolution != "node" &&
+        es_module_specifier_resolution != "explicit") {
+      errors->push_back("invalid value for --es-module-specifier-resolution");
+    }
+  }
+
   if (syntax_check_only && has_eval_string) {
     errors->push_back("either --check or --eval can be used, not both");
   }

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -87,7 +87,7 @@ class EnvironmentOptions : public Options {
   bool abort_on_uncaught_exception = false;
   bool experimental_json_modules = false;
   bool experimental_modules = false;
-  std::string es_module_specifier_resolution = "explicit";
+  std::string es_module_specifier_resolution;
   std::string module_type;
   std::string experimental_policy;
   bool experimental_repl_await = false;


### PR DESCRIPTION
This change makes sure that flags related to `--experimental-modules` cannot be passed without `--experimental-modules`. It also validates the two possible values for `--es-module-specifier-resolution`