### PR TITLE
esm: cpp refactoring update not to use uv_fs_realpath

### DIFF
--- a/lib/internal/modules/esm/default_resolve.js
+++ b/lib/internal/modules/esm/default_resolve.js
@@ -1,16 +1,27 @@
 'use strict';
 
+const internalFS = require('internal/fs/utils');
 const { NativeModule } = require('internal/bootstrap/loaders');
-const { ERR_TYPE_MISMATCH,
-        ERR_UNKNOWN_FILE_EXTENSION } = require('internal/errors').codes;
+const { extname } = require('path');
+const { realpathSync } = require('fs');
 const { getOptionValue } = require('internal/options');
-const experimentalJsonModules = getOptionValue('--experimental-json-modules');
-const { resolve: moduleWrapResolve } = internalBinding('module_wrap');
-const { pathToFileURL, fileURLToPath } = require('internal/url');
-const asyncESM = require('internal/process/esm_loader');
+
 const preserveSymlinks = getOptionValue('--preserve-symlinks');
 const preserveSymlinksMain = getOptionValue('--preserve-symlinks-main');
-const { extname } = require('path');
+const experimentalJsonModules = getOptionValue('--experimental-json-modules');
+
+const { resolve: moduleWrapResolve,
+        getPackageType } = internalBinding('module_wrap');
+const { pathToFileURL, fileURLToPath } = require('internal/url');
+const asyncESM = require('internal/process/esm_loader');
+const { ERR_TYPE_MISMATCH,
+        ERR_UNKNOWN_FILE_EXTENSION } = require('internal/errors').codes;
+
+const realpathCache = new Map();
+
+// const TYPE_NONE = 0;
+const TYPE_COMMONJS = 1;
+const TYPE_MODULE = 2;
 
 const extensionFormatMap = {
   '__proto__': null,
@@ -50,13 +61,24 @@ function resolve(specifier, parentURL) {
   if (isMain)
     parentURL = pathToFileURL(`${process.cwd()}/`).href;
 
-  const { url, type } =
-      moduleWrapResolve(specifier, parentURL,
-                        isMain ? !preserveSymlinksMain : !preserveSymlinks);
+  let url = moduleWrapResolve(specifier, parentURL);
+
+  if (isMain ? !preserveSymlinksMain : !preserveSymlinks) {
+    const real = realpathSync(fileURLToPath(url), {
+      [internalFS.realpathCacheKey]: realpathCache
+    });
+    const old = url;
+    url = pathToFileURL(real);
+    url.search = old.search;
+    url.hash = old.hash;
+  }
+
+  const type = getPackageType(url.href);
 
   const ext = extname(url.pathname);
-  let format =
-      (type !== 2 ? legacyExtensionFormatMap : extensionFormatMap)[ext];
+  const extMap =
+      type !== TYPE_MODULE ? legacyExtensionFormatMap : extensionFormatMap;
+  let format = extMap[ext];
 
   if (isMain && asyncESM.typeFlag) {
     // Conflict between explicit extension (.mjs, .cjs) and --type
@@ -68,8 +90,8 @@ function resolve(specifier, parentURL) {
 
     // Conflict between package scope type and --type
     if (ext === '.js') {
-      if (type === 2 && asyncESM.typeFlag === 'commonjs' ||
-          type === 1 && asyncESM.typeFlag === 'module') {
+      if (type === TYPE_MODULE && asyncESM.typeFlag === 'commonjs' ||
+          type === TYPE_COMMONJS && asyncESM.typeFlag === 'module') {
         throw new ERR_TYPE_MISMATCH(
           fileURLToPath(url), ext, asyncESM.typeFlag, 'scope');
       }
@@ -79,7 +101,7 @@ function resolve(specifier, parentURL) {
     if (isMain && asyncESM.typeFlag)
       format = asyncESM.typeFlag;
     else if (isMain)
-      format = type === 2 ? 'module' : 'commonjs';
+      format = type === TYPE_MODULE ? 'module' : 'commonjs';
     else
       throw new ERR_UNKNOWN_FILE_EXTENSION(fileURLToPath(url),
                                            fileURLToPath(parentURL));

--- a/src/env.h
+++ b/src/env.h
@@ -86,7 +86,7 @@ struct PackageConfig {
     enum Bool { No, Yes };
   };
   struct PackageType {
-    enum Type : uint32_t { None, CommonJS, Module };
+    enum Type : uint32_t { None = 0, CommonJS, Module };
   };
   const Exists::Bool exists;
   const IsValid::Bool is_valid;

--- a/src/module_wrap.h
+++ b/src/module_wrap.h
@@ -65,7 +65,7 @@ class ModuleWrap : public BaseObject {
       const v8::FunctionCallbackInfo<v8::Value>& args);
 
   static void Resolve(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void SetScopeType(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void GetPackageType(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetImportModuleDynamicallyCallback(
       const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetInitializeImportMetaObjectCallback(

--- a/src/node_url.h
+++ b/src/node_url.h
@@ -153,14 +153,6 @@ class URL {
     return context_.fragment;
   }
 
-  void set_fragment(const std::string& fragment) {
-    context_.fragment = fragment;
-  }
-
-  void set_query(const std::string& query) {
-    context_.query = query;
-  }
-
   std::string path() const {
     std::string ret;
     for (const std::string& element : context_.path) {

--- a/test/es-module/test-esm-symlink-type.js
+++ b/test/es-module/test-esm-symlink-type.js
@@ -64,7 +64,7 @@ symlinks.forEach((symlink) => {
                     stdout.includes(symlink.prints)) return;
           assert.fail(`For ${JSON.stringify(symlink)}, ${
             (symlink.errorsWithPreserveSymlinksMain) ?
-              'failed to error' : `errored unexpectedly\n${err}`
+              'failed to error' : 'errored unexpectedly'
           } with --preserve-symlinks-main`);
         } else {
           if (stdout.includes(symlink.prints)) return;


### PR DESCRIPTION
I didn't realise the `uv_fs_realpath` is explicitly something to avoid in the previous refactoring, which only came up with the CI error that the windows drive name was being capitalized.

This adjusts the previous refactoring to share the package cache without using uv_fs_realpath and sticking to the JS implementation.

@MylesBorins this should squash well into the previous refactoring commit.